### PR TITLE
CATS-1943 | Add integration tests for DPL

### DIFF
--- a/.github/workflows/download-mediawiki.sh
+++ b/.github/workflows/download-mediawiki.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+set -ex
+
+MW_BRANCH=$1
+
+wget https://github.com/wikimedia/mediawiki/archive/"$MW_BRANCH".tar.gz -nv
+
+tar -zxf "$MW_BRANCH".tar.gz
+mv mediawiki-"$MW_BRANCH" mediawiki
+
+cd mediawiki
+composer update --prefer-dist --no-progress

--- a/.github/workflows/install-mediawiki.sh
+++ b/.github/workflows/install-mediawiki.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -ex
+
+cd mediawiki
+
+# actions/cache doesn't seem to honor excluding it, so just get rid of it
+rm LocalSettings.php || echo 'no LocalSettings.php file to remove'
+
+# MySQL might still be initializing so give it some time
+php -- <<'EOPHP'
+<?php
+$user = getenv( 'MYSQL_USER' );
+$pass = getenv( 'MYSQL_PASSWORD' );
+$db = getenv( 'MYSQL_DATABASE' );
+$stderr = fopen('php://stderr', 'w');
+$maxTries = 10;
+do {
+	$mysql = new mysqli( '127.0.0.1', $user, $pass, $db, 3306 );
+	if ($mysql->connect_error) {
+		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
+		--$maxTries;
+		if ($maxTries <= 0) {
+			exit(1);
+		}
+		sleep(3);
+	}
+} while ($mysql->connect_error);
+$mysql->close();
+EOPHP
+
+php maintenance/install.php \
+	--dbtype mysql \
+	--dbserver 127.0.0.1 \
+    --dbuser "$MYSQL_USER" \
+    --dbpass "$MYSQL_PASSWORD" \
+    --dbname "$MYSQL_DATABASE" \
+    --pass AdminPassword \
+    WikiName \
+    AdminUser
+{
+	echo 'error_reporting( E_ALL | E_STRICT );'
+	echo 'ini_set("display_errors", 1);'
+	echo '$wgShowExceptionDetails = true;'
+	echo '$wgShowDBErrorBacktrace = true;'
+	echo '$wgDevelopmentWarnings = true;'
+	echo 'wfLoadExtension( "DynamicPageList3" );'
+} >> LocalSettings.php

--- a/.github/workflows/php-lint-cs.yml
+++ b/.github/workflows/php-lint-cs.yml
@@ -7,14 +7,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php: ['7.3', '8.0']
     steps:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: ${{ matrix.php }}
+        php-version: '8.0'
     - uses: actions/checkout@v2
 
     - name: Validate composer.json and composer.lock
@@ -25,9 +22,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: vendor
-        key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
-          ${{ runner.os }}-php-${{ matrix.php }}
+          ${{ runner.os }}-php
 
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -1,0 +1,98 @@
+name: PHPUnit tests
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  test:
+    name: "MediaWiki ${{ matrix.mw }} | PHP ${{ matrix.php }} | MySQL ${{ matrix.mysql }}"
+    strategy:
+      matrix:
+        include:
+          # Fandom's MW version
+          - mw: 'REL1_33'
+            php: 7.3
+            composer: v1
+            mysql: '5.7'
+          # Latest stable MW
+          - mw: 'REL1_36'
+            php: 8.0
+            composer: v2
+            mysql: '8.0'
+          # Latest MW master
+          - mw: 'master'
+            php: 8.0
+            composer: v2
+            mysql: '8.0'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mediawiki
+    services:
+      mysql:
+        image: mysql:${{ matrix.mysql }}
+        options: --name integration-tests-mysql
+        env:
+          MYSQL_ROOT_PASSWORD: root123
+          MYSQL_DATABASE: mwtest
+          MYSQL_USER: mwuser
+          MYSQL_PASSWORD: mw12345
+        ports:
+        - 3306:3306
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: intl
+          tools: composer:${{ matrix.composer }}
+      - name: Cache MediaWiki
+        id: cache-mediawiki
+        uses: actions/cache@v2
+        with:
+          path: |
+            mediawiki
+            !mediawiki/extensions/
+            !mediawiki/vendor/
+          key: mw-${{ matrix.mw }}-php${{ matrix.php }}-v2
+
+      - name: Cache Composer cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.composer/cache
+          key: composer-php${{ matrix.php }}
+
+      - name: Fetch MW install script
+        uses: actions/checkout@v2
+        with:
+          path: installer
+
+      - name: Download MediaWiki
+        if: steps.cache-mediawiki.outputs.cache-hit != 'true'
+        working-directory: ~
+        run: bash installer/.github/workflows/download-mediawiki.sh ${{ matrix.mw }}
+
+      - name: Install MediaWiki
+        working-directory: ~
+        run: bash installer/.github/workflows/install-mediawiki.sh
+        env:
+          MYSQL_DATABASE: mwtest
+          MYSQL_USER: mwuser
+          MYSQL_PASSWORD: mw12345
+
+      - name: Checkout DPL extension
+        uses: actions/checkout@v2
+        with:
+          path: mediawiki/extensions/DynamicPageList3
+
+      - name: Run PHPUnit
+        run: |
+          [[ '${{ matrix.mw }}' != 'master' ]] && PHPUNIT_ARGS='--use-normal-tables' ||  PHPUNIT_ARGS=''
+          php tests/phpunit/phpunit.php $PHPUNIT_ARGS extensions/DynamicPageList3/tests/phpunit
+
+        env:
+          # By default MediaWiki creates temporary tables for use in integration tests,
+          # which do not play well with DPL's queries. Ensure we use real tables to avoid issues.
+          # https://dev.mysql.com/doc/refman/8.0/en/temporary-table-problems.html
+          PHPUNIT_USE_NORMAL_TABLES: 1

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -14,6 +14,8 @@
 		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment.NewLineComment" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.WrongStyle" />
 		<exclude name="Generic.PHP.NoSilencedErrors.Discouraged" />
+
+		<exclude name="MediaWiki.Commenting.MissingCovers.MissingCovers" />
 	</rule>
     <file>.</file>
     <arg name="encoding" value="utf8"/>

--- a/classes/Article.php
+++ b/classes/Article.php
@@ -10,6 +10,7 @@
  */
 namespace DPL;
 
+use MediaWiki\MediaWikiServices;
 use Title;
 use User;
 
@@ -207,7 +208,9 @@ class Article {
 	 * @return Article \DPL\Article Object
 	 */
 	public static function newFromRow( $row, Parameters $parameters, \Title $title, $pageNamespace, $pageTitle ) {
-		global $wgLang, $wgContLang;
+		global $wgLang;
+
+		$contentLanguage = MediaWikiServices::getInstance()->getContentLanguage();
 
 		$article = new Article( $title, $pageNamespace );
 
@@ -234,9 +237,9 @@ class Article {
 
 		// get first char used for category-style output
 		if ( isset( $row['sortkey'] ) ) {
-			$article->mStartChar = $wgContLang->convert( $wgContLang->firstChar( $row['sortkey'] ) );
+			$article->mStartChar = $contentLanguage->convert( $contentLanguage->firstChar( $row['sortkey'] ) );
 		} else {
-			$article->mStartChar = $wgContLang->convert( $wgContLang->firstChar( $pageTitle ) );
+			$article->mStartChar = $contentLanguage->convert( $contentLanguage->firstChar( $pageTitle ) );
 		}
 
 		$article->mID = intval( $row['page_id'] );

--- a/classes/Parameters.php
+++ b/classes/Parameters.php
@@ -10,6 +10,8 @@
  */
 namespace DPL;
 
+use MediaWiki\MediaWikiServices;
+
 class Parameters extends ParametersData {
 	/**
 	 * Set parameter options.
@@ -634,11 +636,12 @@ class Parameters extends ParametersData {
 	 * @return bool Success
 	 */
 	public function _namespace( $option ) {
-		global $wgContLang;
 		$extraParams = explode( '|', $option );
 		foreach ( $extraParams as $parameter ) {
 			$parameter = trim( $parameter );
-			$namespaceId = $wgContLang->getNsIndex( $parameter );
+			$namespaceId = MediaWikiServices::getInstance()
+				->getContentLanguage()
+				->getNsIndex( $parameter );
 			if ( $namespaceId === false || ( is_array( Config::getSetting( 'allowedNamespaces' ) ) && !in_array( $parameter, Config::getSetting( 'allowedNamespaces' ) ) ) ) {
 				// Let the user know this namespace is not allowed or does not exist.
 				return false;
@@ -848,10 +851,8 @@ class Parameters extends ParametersData {
 	 * @return bool Success
 	 */
 	public function _titleregexp( $option ) {
-		$data = $this->getParameter( 'title' );
-		if ( !is_array( $data['regexp'] ) ) {
-			$data['regexp'] = [];
-		}
+		$data = $this->getParameter( 'title' ) ?? [ 'regexp' => [] ];
+
 		$newMatches = explode( '|', str_replace( ' ', '\_', $option ) );
 
 		if ( !$this->isRegexValid( $newMatches, true ) ) {
@@ -872,10 +873,8 @@ class Parameters extends ParametersData {
 	 * @return bool Success
 	 */
 	public function _titlematch( $option ) {
-		$data = $this->getParameter( 'title' );
-		if ( !is_array( $data['like'] ) ) {
-			$data['like'] = [];
-		}
+		$data = $this->getParameter( 'title' ) ?? [ 'like' => [] ];
+
 		$newMatches = explode( '|', str_replace( ' ', '\_', $option ) );
 		$data['like'] = array_merge( $data['like'], $newMatches );
 		$this->setParameter( 'title', $data );

--- a/classes/Parse.php
+++ b/classes/Parse.php
@@ -12,6 +12,7 @@ namespace DPL;
 
 use DPL\Heading\Heading;
 use DPL\Lister\Lister;
+use MediaWiki\MediaWikiServices;
 use Parser;
 use Wikimedia\Rdbms\IDatabase;
 
@@ -883,7 +884,7 @@ class Parse {
 	private function triggerEndResets( $output, &$reset, &$eliminate, $isParserTag ) {
 		global $wgHooks;
 
-		$localParser = new \Parser();
+		$localParser = MediaWikiServices::getInstance()->getParserFactory()->create();
 		$parserOutput = $localParser->parse( $output, $this->parser->mTitle, $this->parser->mOptions );
 
 		if ( !is_array( $reset ) ) {

--- a/classes/Query.php
+++ b/classes/Query.php
@@ -10,6 +10,7 @@
  */
 namespace DPL;
 
+use MediaWiki\MediaWikiServices;
 use Wikimedia\Rdbms\IDatabase;
 
 class Query {
@@ -949,7 +950,7 @@ class Query {
 		if ( is_numeric( $option[0] ) ) {
 			$this->addWhere( intval( $option[0] ) . ' <= (SELECT count(*) FROM ' . $this->tableNames['categorylinks'] . ' WHERE ' . $this->tableNames['categorylinks'] . '.cl_from=page_id)' );
 		}
-		if ( is_numeric( $option[1] ) ) {
+		if ( isset( $option[1] ) && is_numeric( $option[1] ) ) {
 			$this->addWhere( intval( $option[1] ) . ' >= (SELECT count(*) FROM ' . $this->tableNames['categorylinks'] . ' WHERE ' . $this->tableNames['categorylinks'] . '.cl_from=page_id)' );
 		}
 	}
@@ -1643,14 +1644,13 @@ class Query {
 	 * @return void
 	 */
 	private function _ordermethod( $option ) {
-		global $wgContLang;
-
 		if ( $this->parameters->getParameter( 'goal' ) == 'categories' ) {
 			// No order methods for returning categories.
 			return true;
 		}
 
-		$namespaces = $wgContLang->getNamespaces();
+		$services = MediaWikiServices::getInstance();
+		$namespaces = $services->getContentLanguage()->getNamespaces();
 		// $aStrictNs = array_slice((array) Config::getSetting('allowedNamespaces'), 1, count(Config::getSetting('allowedNamespaces')), true);
 		$namespaces = array_slice( $namespaces, 3, count( $namespaces ), true );
 		$_namespaceIdToText = "CASE {$this->tableNames['page']}.page_namespace";

--- a/classes/lister/Lister.php
+++ b/classes/lister/Lister.php
@@ -14,6 +14,7 @@ use DPL\Article;
 use DPL\LST;
 use DPL\Parameters;
 use DPL\UpdateArticle;
+use MediaWiki\MediaWikiServices;
 use Parser;
 
 class Lister {
@@ -786,9 +787,7 @@ class Lister {
 	 * @return string Text with replacements performed.
 	 */
 	protected function replaceTagParameters( $tag, Article $article ) {
-		global $wgContLang;
-
-		$namespaces = $wgContLang->getNamespaces();
+		$namespaces = MediaWikiServices::getInstance()->getContentLanguage()->getNamespaces();
 
 		if ( strpos( $tag, '%' ) === false ) {
 			return $tag;

--- a/extension.json
+++ b/extension.json
@@ -56,7 +56,9 @@
 		"DPL\\Query": "classes/Query.php",
 		"DPL\\UpdateArticle": "classes/UpdateArticle.php",
 		"DPL\\Variables": "classes/Variables.php",
-		"DynamicPageListHooks": "DynamicPageListHooks.php"
+		"DPL\\SeedTestDatabase": "classes/SeedTestDatabase.php",
+		"DynamicPageListHooks": "DynamicPageListHooks.php",
+		"DPL\\DPLIntegrationTestCase": "tests/phpunit/DPLIntegrationTestCase.php"
 	},
 	"Hooks": {
 		"ParserFirstCallInit": [

--- a/tests/phpunit/DPLIntegrationTestCase.php
+++ b/tests/phpunit/DPLIntegrationTestCase.php
@@ -1,0 +1,167 @@
+<?php
+namespace DPL;
+
+use DOMDocument;
+use DOMXPath;
+use ImportStreamSource;
+use MediaWiki\Auth\AuthManager;
+use MediaWiki\MediaWikiServices;
+use MediaWikiTestCase;
+use ParserOptions;
+use RequestContext;
+use Title;
+use User;
+use WikiImporter;
+
+abstract class DPLIntegrationTestCase extends MediaWikiTestCase {
+	/**
+	 * Guard condition to ensure we only import seed data once per test suite run.
+	 * @var bool
+	 */
+	private static $wasSeedDataImported = false;
+
+	public function addDBDataOnce() {
+		if ( self::$wasSeedDataImported ) {
+			return;
+		}
+
+		$seedDataPath = __DIR__ . '/../seed-data.xml';
+		$this->seedTestUsers( $seedDataPath );
+		$importer = $this->getWikiImporter( $seedDataPath );
+		$importer->disableStatisticsUpdate();
+		// Ensure we actually create local user accounts in the DB
+		$importer->setUsernamePrefix( '', true );
+		$importer->doImport();
+
+		self::$wasSeedDataImported = true;
+	}
+
+	/**
+	 * Import test accounts from seed data so that DPL queries can refer to them.
+	 * @param string $seedDataPath - path to seed data to be loaded
+	 */
+	private function seedTestUsers( string $seedDataPath ): void {
+		$doc = new DOMDocument();
+		$doc->preserveWhiteSpace = false;
+		$doc->load( $seedDataPath );
+
+		$xpath = new DOMXPath( $doc );
+		$xpath->registerNamespace( 'mw', 'http://www.mediawiki.org/xml/export-0.11/' );
+
+		$userNodes = $xpath->query( '//mw:mediawiki/mw:page/mw:revision/mw:contributor/mw:username' );
+		$usersByName = [];
+
+		$authManager = $this->getAuthManager();
+
+		foreach ( $userNodes as $node ) {
+			$userName = $node->nodeValue;
+
+			// Already created
+			if ( isset( $usersByName[$userName] ) ) {
+				continue;
+			}
+
+			$usersByName[$userName] = true;
+			$user = $this->newUserFromName( $userName );
+
+			if ( !$user || $user->idForName() !== 0 ) {
+				return; // sanity
+			}
+
+			$status = $authManager->autoCreateUser(
+				$user,
+				$authManager::AUTOCREATE_SOURCE_MAINT,
+				false
+			);
+
+			if ( !$status->isOK() ) {
+				return;
+			}
+		}
+	}
+
+	private function getWikiImporter( string $seedDataPath ): WikiImporter {
+		$seedDataFile = fopen( $seedDataPath, 'rt' );
+		$source = new ImportStreamSource( $seedDataFile );
+		$services = MediaWikiServices::getInstance();
+
+		if ( $services->hasService( 'WikiImporterFactory' ) ) {
+			return $services->getWikiImporterFactory()->getWikiImporter( $source );
+		}
+
+		// MW 1.33
+		return new WikiImporter( $source, $services->getMainConfig() );
+	}
+
+	private function getAuthManager(): AuthManager {
+		$services = MediaWikiServices::getInstance();
+		if ( $services->hasService( 'AuthManager' ) ) {
+			return $services->getAuthManager();
+		}
+
+		// MW 1.33
+		return AuthManager::singleton();
+	}
+
+	private function newUserFromName( string $name ): ?User {
+		$services = MediaWikiServices::getInstance();
+
+		if ( $services->hasService( 'UserFactory' ) ) {
+			$factory = $services->getUserFactory();
+			return $factory->newFromName( $name, $factory::RIGOR_CREATABLE );
+		}
+
+		// MW 1.33
+		$user = User::newFromName( $name );
+		return $user ?: null;
+	}
+
+	/**
+	 * Convenience function to return the list of page titles matching a DPL query
+	 * @param array $params - DPL invocation parameters
+	 * @return string[]
+	 */
+	protected function getDPLQueryResults( array $params ): array {
+		$params += [
+			// Use a custom format for executing the query to allow easily extracting results
+			'format' => '<div id="dpl-test-query">,%PAGE%,|,</div>'
+		];
+
+		$html = $this->runDPLQuery( $params );
+		$doc = new DOMDocument();
+		$doc->loadHTML( $html );
+		$queryResults = $doc->getElementById( 'dpl-test-query' );
+		if ( $queryResults ) {
+			return explode( "|", rtrim( $queryResults->textContent, "|" ) );
+		}
+
+		return [];
+	}
+
+	/**
+	 * Build and execute a DPL invocation using the given parameters and return the HTML output.
+	 * @param array $params
+	 * @return string
+	 */
+	protected function runDPLQuery( array $params ): string {
+		$invocation = '<dpl>';
+
+		foreach ( $params as $paramName => $values ) {
+			$values = (array)$values; // multi-value parameters
+			foreach ( $values as $value ) {
+				$invocation .= "$paramName=$value\n";
+			}
+		}
+
+		$invocation .= '</dpl>';
+
+		$parser = MediaWikiServices::getInstance()->getParser();
+		$title = Title::makeTitle( NS_MAIN, 'DPLQueryTest' );
+		$parserOptions = ParserOptions::newCanonical(
+			RequestContext::getMain()
+		);
+		$parserOutput = $parser->parse( $invocation, $title, $parserOptions );
+
+		return $parserOutput->getText();
+	}
+}

--- a/tests/phpunit/DPLQueryIntegrationTest.php
+++ b/tests/phpunit/DPLQueryIntegrationTest.php
@@ -1,0 +1,182 @@
+<?php
+namespace DPL;
+
+class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
+
+	public function testFindPagesInCategory(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 1', 'DPLTestArticle 2', 'DPLTestArticle 3', 'DPLTestArticleMultipleCategories' ],
+			$this->getDPLQueryResults( [ 'category' => 'DPLTestCategory' ] ),
+			true
+		);
+	}
+
+	public function testFindPagesInCategoryWithOrderAndLimit(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticleMultipleCategories', 'DPLTestArticle 3', ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestCategory',
+				'ordermethod' => 'sortkey',
+				'order' => 'descending',
+				'count' => '2'
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesNotInCategory(): void {
+		$results = $this->getDPLQueryResults( [
+			'namespace' => '', // NS_MAIN
+			'notcategory' => 'DPLTestCategory'
+		] );
+
+		$this->assertContains( 'DPLTestArticleNoCategory', $results );
+		foreach ( [ 'DPLTestArticle 1', 'DPLTestArticle 2', 'DPLTestArticle 3' ] as $pageInCat ) {
+			$this->assertNotContains( $pageInCat, $results );
+		}
+	}
+
+	public function testFindPagesNotInCategoryByPrefix(): void {
+		$results = $this->getDPLQueryResults( [
+			'namespace' => '', // NS_MAIN
+			'titlematch' => 'DPLTest%',
+			'notcategory' => 'DPLTestCategory'
+		] );
+
+		$this->assertArrayEquals(
+			[ 'DPLTestArticleNoCategory', 'DPLTestArticleOtherCategoryWithInfobox' ],
+			$results,
+			true
+		);
+	}
+
+	public function testFindPagesByPrefix(): void {
+		$results = $this->getDPLQueryResults( [
+			'namespace' => '', // NS_MAIN
+			'titlematch' => 'DPLTest%',
+		] );
+
+		$this->assertNotEmpty( $results );
+
+		foreach ( $results as $result ) {
+			$this->assertStringStartsWith( 'DPLTest', $result );
+		}
+	}
+
+	public function testFindPagesInCategoryIntersection(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticleMultipleCategories' ],
+			$this->getDPLQueryResults( [
+				'category' => [ 'DPLTestCategory', 'DPLTestOtherCategory' ]
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesUsingTemplate(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 1', 'DPLTestArticleOtherCategoryWithInfobox' ],
+			$this->getDPLQueryResults( [
+				'uses' => 'Template:DPLInfobox'
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesInCategoryUsingTemplate(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticleOtherCategoryWithInfobox' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestOtherCategory',
+				'uses' => 'Template:DPLInfobox'
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesNotInCategoryUsingTemplate(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 1' ],
+			$this->getDPLQueryResults( [
+				'notcategory' => 'DPLTestOtherCategory',
+				'uses' => 'Template:DPLInfobox'
+			] ),
+			true
+		);
+	}
+
+	public function testFindTemplatesUsedByPage(): void {
+		$this->assertArrayEquals(
+			[ 'Template:DPLInfobox' ],
+			$this->getDPLQueryResults( [
+				'usedby' => 'DPLTestArticleOtherCategoryWithInfobox'
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesByTitleRegexpInNamespace(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 1', 'DPLTestArticle 2' ],
+			$this->getDPLQueryResults( [
+				'namespace' => '', // NS_MAIN
+				'titleregexp' => 'DPLTestArticle [12]'
+			] )
+		);
+	}
+
+	public function testFindPagesBeforeTitleInCategory(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 1', 'DPLTestArticle 2' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestCategory',
+				'titlelt' => 'DPLTestArticle 3',
+				'count' => '2'
+			] )
+		);
+	}
+
+	public function testFindPagesInCategoryWithMaxRevisionLimit(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 2', 'DPLTestArticleMultipleCategories' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestCategory',
+				'maxrevisions' => '1',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesInCategoryWithMinRevisionLimit(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 1', 'DPLTestArticle 3' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestCategory',
+				'minrevisions' => '2',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesByCategoryMin(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticleMultipleCategories' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestCategory',
+				'categoriesminmax' => '2',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesByCategoryMinMax(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 1', 'DPLTestArticle 2', 'DPLTestArticle 3' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestCategory',
+				'categoriesminmax' => '1,1',
+			] ),
+			true
+		);
+	}
+}

--- a/tests/seed-data.xml
+++ b/tests/seed-data.xml
@@ -1,0 +1,254 @@
+<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.11/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.11/ http://www.mediawiki.org/xml/export-0.11.xsd" version="0.11" xml:lang="en">
+	<siteinfo>
+		<sitename>MediaWiki</sitename>
+		<dbname>mwdev</dbname>
+		<base>http://localhost:8080/wiki/Main_Page</base>
+		<generator>MediaWiki 1.37.0-alpha</generator>
+		<case>first-letter</case>
+		<namespaces>
+			<namespace key="-2" case="first-letter">Media</namespace>
+			<namespace key="-1" case="first-letter">Special</namespace>
+			<namespace key="0" case="first-letter" />
+			<namespace key="1" case="first-letter">Talk</namespace>
+			<namespace key="2" case="first-letter">User</namespace>
+			<namespace key="3" case="first-letter">User talk</namespace>
+			<namespace key="4" case="first-letter">Project</namespace>
+			<namespace key="5" case="first-letter">Project talk</namespace>
+			<namespace key="6" case="first-letter">File</namespace>
+			<namespace key="7" case="first-letter">File talk</namespace>
+			<namespace key="8" case="first-letter">MediaWiki</namespace>
+			<namespace key="9" case="first-letter">MediaWiki talk</namespace>
+			<namespace key="10" case="first-letter">Template</namespace>
+			<namespace key="11" case="first-letter">Template talk</namespace>
+			<namespace key="12" case="first-letter">Help</namespace>
+			<namespace key="13" case="first-letter">Help talk</namespace>
+			<namespace key="14" case="first-letter">Category</namespace>
+			<namespace key="15" case="first-letter">Category talk</namespace>
+		</namespaces>
+	</siteinfo>
+	<page>
+		<title>Template:DPLInfobox</title>
+		<ns>10</ns>
+		<id>13</id>
+		<revision>
+			<id>13</id>
+			<timestamp>2017-09-07T10:45:24Z</timestamp>
+			<contributor>
+				<username>FANDOM</username>
+			</contributor>
+			<comment>Test template</comment>
+			<origin>13</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text xml:space="preserve" bytes="13">Test template</text>
+			<sha1 />
+		</revision>
+	</page>
+	<page>
+		<title>Category:DPLTestCategory</title>
+		<ns>14</ns>
+		<id>14</id>
+		<revision>
+			<id>17</id>
+			<timestamp>2021-09-02T14:42:11Z</timestamp>
+			<contributor>
+				<username>DPLTestAdmin</username>
+				<id>1</id>
+			</contributor>
+			<comment>Created page with "DPL Test category"</comment>
+			<origin>17</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text bytes="17" sha1="7fvwcsar4s6wpu5l22vedd9yaek5js6" xml:space="preserve">DPL Test category</text>
+			<sha1>7fvwcsar4s6wpu5l22vedd9yaek5js6</sha1>
+		</revision>
+	</page>
+	<page>
+		<title>DPLTestArticle 1</title>
+		<ns>0</ns>
+		<id>15</id>
+		<revision>
+			<id>18</id>
+			<timestamp>2021-09-02T14:43:05Z</timestamp>
+			<contributor>
+				<username>DPLTestAdmin</username>
+				<id>1</id>
+			</contributor>
+			<comment>Initial page version</comment>
+			<origin>18</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text xml:space="preserve">Donec non dolor ipsum.
+[[Category:DPLTestCategory]]</text>
+			<sha1 />
+		</revision>
+		<revision>
+			<id>19</id>
+			<parentid>18</parentid>
+			<timestamp>2021-09-02T14:43:16Z</timestamp>
+			<contributor>
+				<username>DPLTestUser</username>
+				<id>2</id>
+			</contributor>
+			<comment>Edited version</comment>
+			<origin>19</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text xml:space="preserve">Sed mollis dignissim [[DPLTestArticle 2]] purus, auctor faucibus [[DPLTestArticleNoCategory]] purus tincidunt at. {{DPLInfobox}}
+[[Category:DPLTestCategory]]</text>
+			<sha1 />
+		</revision>
+	</page>
+	<page>
+		<title>DPLTestArticle 2</title>
+		<ns>0</ns>
+		<id>16</id>
+		<revision>
+			<id>20</id>
+			<timestamp>2021-09-02T14:44:01Z</timestamp>
+			<contributor>
+				<username>DPLTestAdmin</username>
+				<id>1</id>
+			</contributor>
+			<comment>Initial page version</comment>
+			<origin>20</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text bytes="72" sha1="gykofop7mtvar8ajsyppok80uy6fiti" xml:space="preserve">Sed dapibus enim ac quam pharetra suscipit.
+[[Category:DPLTestCategory]]</text>
+			<sha1>gykofop7mtvar8ajsyppok80uy6fiti</sha1>
+		</revision>
+	</page>
+	<page>
+		<title>DPLTestArticle 3</title>
+		<ns>0</ns>
+		<id>17</id>
+		<revision>
+			<id>21</id>
+			<timestamp>2019-08-12T00:11:23Z</timestamp>
+			<contributor>
+				<username>DPLTestAdmin</username>
+				<id>1</id>
+			</contributor>
+			<comment>Initial page version</comment>
+			<origin>21</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text bytes="95" sha1="og8hxtaxjfid8cinjh7nq5g2zxv0cdj" xml:space="preserve">Vestibulum a ante aliquet, vestibulum risus vitae, imperdiet sem.
+[[Category:DPLTestCategory]]</text>
+			<sha1>og8hxtaxjfid8cinjh7nq5g2zxv0cdj</sha1>
+		</revision>
+		<revision>
+			<id>22</id>
+			<parentid>21</parentid>
+			<timestamp>2021-09-02T14:44:47Z</timestamp>
+			<contributor>
+				<username>DPLTestAdmin</username>
+				<id>1</id>
+			</contributor>
+			<comment>Edited version</comment>
+			<origin>22</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text bytes="73" sha1="9caafrpllg2n9zyk52h0ov4bajyxjpj" xml:space="preserve"> Duis vel dapibus tellus, eu vehicula metus.
+[[Category:DPLTestCategory]]</text>
+			<sha1>9caafrpllg2n9zyk52h0ov4bajyxjpj</sha1>
+		</revision>
+	</page>
+	<page>
+		<title>DPLTestArticleNoCategory</title>
+		<ns>0</ns>
+		<id>18</id>
+		<revision>
+			<id>23</id>
+			<timestamp>2021-09-03T00:12:20Z</timestamp>
+			<contributor>
+				<username>DPLTestUser</username>
+				<id>2</id>
+			</contributor>
+			<comment>Create test page without category</comment>
+			<origin>23</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text bytes="40" xml:space="preserve">Urbem praeclaram statui, mea moenia vidi</text>
+			<sha1 />
+		</revision>
+	</page>
+	<page>
+		<title>Category:DPLTestOtherCategory</title>
+		<ns>14</ns>
+		<id>24</id>
+		<revision>
+			<id>24</id>
+			<timestamp>2021-09-02T14:42:11Z</timestamp>
+			<contributor>
+				<username>DPLTestAdmin</username>
+				<id>1</id>
+			</contributor>
+			<comment>Created page with "DPL Test category"</comment>
+			<origin>24</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text bytes="18" xml:space="preserve">DPL other category</text>
+			<sha1 />
+		</revision>
+	</page>
+	<page>
+		<title>DPLTestArticleMultipleCategories</title>
+		<ns>0</ns>
+		<id>25</id>
+		<revision>
+			<id>25</id>
+			<timestamp>2021-09-02T14:44:01Z</timestamp>
+			<contributor>
+				<username>DPLTestAdmin</username>
+				<id>1</id>
+			</contributor>
+			<comment>Page with multiple categories</comment>
+			<origin>25</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text bytes="117" xml:space="preserve">Quo usque tandem abutere, Catilina, patientia nostra?!
+[[Category:DPLTestOtherCategory]]
+[[Category:DPLTestCategory]]</text>
+			<sha1 />
+		</revision>
+	</page>
+	<page>
+		<title>DPLTestArticleOtherCategoryWithInfobox</title>
+		<ns>0</ns>
+		<id>26</id>
+		<revision>
+			<id>26</id>
+			<timestamp>2021-09-02T14:44:01Z</timestamp>
+			<contributor>
+				<username>FANDOM</username>
+			</contributor>
+			<comment>Page with infobox</comment>
+			<origin>25</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text xml:space="preserve">{{DPLInfobox}} some content
+[[Category:DPLTestOtherCategory]]]</text>
+			<sha1 />
+		</revision>
+	</page>
+	<page>
+		<title>DPLUncategorizedPage</title>
+		<ns>0</ns>
+		<id>27</id>
+		<revision>
+			<id>27</id>
+			<timestamp>2021-09-04T03:01:00Z</timestamp>
+			<contributor>
+				<username>FANDOM</username>
+			</contributor>
+			<comment>Create test uncategorized page</comment>
+			<origin>27</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text xml:space="preserve">Uncategorized test page</text>
+			<sha1 />
+		</revision>
+	</page>
+</mediawiki>


### PR DESCRIPTION
In preparation for updating DPL to handle actor migration properly, add
an integration tests framework to facilitate making those changes with
more confidence. Also fix various errors found during initial test
execution that prevented the tests from running on the latest MW master.