### PR TITLE
CATS-1829 | Implement actor table handling

### DIFF
--- a/classes/Article.php
+++ b/classes/Article.php
@@ -12,7 +12,6 @@ namespace DPL;
 
 use MediaWiki\MediaWikiServices;
 use Title;
-use User;
 
 class Article {
 	/**
@@ -310,13 +309,7 @@ class Article {
 			// CONTRIBUTION, CONTRIBUTOR
 			if ( $parameters->getParameter( 'addcontribution' ) ) {
 				$article->mContribution = $row['contribution'];
-				// This is the wrong check since the ActorMigration may be in progress
-				// https://www.mediawiki.org/wiki/Actor_migration
-				if ( class_exists( 'ActorMigration' ) ) {
-					$article->mContributor = User::newFromActorId( $row['contributor'] )->getName();
-				} else {
-					$article->mContributor = $row['contributor'];
-				}
+				$article->mContributor = $row['contributor'];
 				$article->mContrib = substr( '*****************', 0, (int)round( log( $row['contribution'] ) ) );
 			}
 

--- a/classes/Parse.php
+++ b/classes/Parse.php
@@ -10,6 +10,7 @@
  */
 namespace DPL;
 
+use ActorMigration;
 use DPL\Heading\Heading;
 use DPL\Lister\Lister;
 use MediaWiki\MediaWikiServices;
@@ -219,7 +220,9 @@ class Parse {
 		/* Query */
 		/*********/
 		try {
-			$this->query = new Query( $this->parameters );
+			$actorMigration = ActorMigration::newMigration();
+			$commentStore = MediaWikiServices::getInstance()->getCommentStore();
+			$this->query = new Query( $this->parameters, $actorMigration, $commentStore );
 			$result = $this->query->buildAndSelect( $calcRows );
 		} catch ( MWException $e ) {
 			$this->logger->addMessage( \DynamicPageListHooks::FATAL_SQLBUILDERROR, $e->getMessage() );

--- a/classes/RevisionJoinBuilder.php
+++ b/classes/RevisionJoinBuilder.php
@@ -1,0 +1,121 @@
+<?php
+namespace DPL;
+
+use ActorMigration;
+use CommentStore;
+use Wikimedia\Rdbms\IDatabase;
+
+/**
+ * Helper class to manage JOIN conditions against the revision table and related actor tables.
+ */
+class RevisionJoinBuilder {
+	/** @var IDatabase */
+	private $dbr;
+	/** @var ActorMigration */
+	private $actorMigration;
+	/** @var CommentStore */
+	private $commentStore;
+
+	/**
+	 * List of fields to select from the first revision of the article, keyed by alias.
+	 * @var string[]
+	 */
+	private $firstRevisionFields = [];
+	/**
+	 * List of fields to select from the last revision of the article, keyed by alias.
+	 * @var string[]
+	 */
+	private $lastRevisionFields = [];
+
+	public function __construct(
+		IDatabase $dbr,
+		ActorMigration $actorMigration,
+		CommentStore $commentStore
+	) {
+		$this->dbr = $dbr;
+		$this->actorMigration = $actorMigration;
+		$this->commentStore = $commentStore;
+	}
+
+	public function addFieldsFromFirst( array $fields ): void {
+		$this->firstRevisionFields += $fields;
+	}
+
+	public function addFieldsFromLast( array $fields ): void {
+		$this->lastRevisionFields += $fields;
+	}
+
+	public function getQueryInfo(): array {
+		$queryInfo = [
+			'fields' => [],
+			'tables' => [],
+			'joins' => [],
+		];
+
+		return array_merge_recursive(
+			$queryInfo,
+			$this->addRevisionQueryInfo(
+				'latest_rev',
+				$this->lastRevisionFields,
+				[ 'rev_id=page_latest' ]
+			),
+			$this->addRevisionQueryInfo(
+				'first_rev',
+				$this->firstRevisionFields,
+				[
+					'rev_page=page_id',
+					'rev_parent_id' => 0,
+				]
+			)
+		);
+	}
+
+	private function addRevisionQueryInfo(
+		string $tableAlias,
+		array $fieldsByAlias,
+		array $joinConds
+	): array {
+		if ( !$fieldsByAlias ) {
+			return [];
+		}
+
+		$fieldsByAlias += [ 'rev_id', 'rev_page', 'rev_parent_id' ];
+
+		$actorQuery = $this->actorMigration->getJoin( 'rev_user' );
+		$commentQuery = $this->commentStore->getJoin( 'rev_comment' );
+
+		// Ensure we correctly fetch aliased fields such as rev_user
+		// from the revision_actor_temp table if it is active.
+		$actorFields = array_keys( $actorQuery['fields'] );
+		$revFields = array_diff( $fieldsByAlias, $actorFields );
+
+		// Since multiple instances of the revision and associated actor tables may be used per
+		// query, join on the derived result of an aliased subquery to avoid naming conflicts.
+		$revQuery = $this->dbr->buildSelectSubquery(
+			[ $tableAlias => 'revision' ] + $actorQuery['tables'] + $commentQuery['tables'],
+			$actorQuery['fields'] + $commentQuery['fields'] + array_values( $revFields ),
+			[],
+			__METHOD__,
+			[],
+			$actorQuery['joins'] + $commentQuery['joins']
+		);
+
+		$fieldsWithPrefix = [];
+		$quotedTableAlias = $this->dbr->addIdentifierQuotes( $tableAlias );
+
+		foreach ( $fieldsByAlias as $alias => $revFieldName ) {
+			$quotedRevField = $this->dbr->addIdentifierQuotes( $revFieldName );
+			$fieldsWithPrefix[$alias] = "$quotedTableAlias.$quotedRevField";
+		}
+
+		return [
+			'fields' => $fieldsWithPrefix,
+			'tables' => [
+				$tableAlias => $revQuery
+			],
+			'joins' => [
+				$tableAlias => [ 'JOIN', $joinConds ]
+			]
+		];
+	}
+}

--- a/classes/UserQueryBuilder.php
+++ b/classes/UserQueryBuilder.php
@@ -1,0 +1,158 @@
+<?php
+namespace DPL;
+
+use ActorMigration;
+use MediaWiki\User\UserIdentity;
+use User;
+use Wikimedia\Rdbms\IDatabase;
+
+/**
+ * Helper class for adding user-specific criteria (e.g. last edited by) to a DPL query
+ */
+class UserQueryBuilder {
+	/** @var IDatabase */
+	private $dbr;
+	/**
+	 * @var ActorMigration
+	 */
+	private $actorMigration;
+
+	/** @var UserIdentity[] */
+	private $modifiedByConstraints = [];
+	/** @var UserIdentity[] */
+	private $notModifiedByConstraints = [];
+
+	/** @var UserIdentity[] */
+	private $notCreatedByConstraints = [];
+	/** @var UserIdentity[] */
+	private $notLastModifiedByConstraints = [];
+
+	/** @var UserIdentity */
+	private $createdByConstraint;
+	/** @var UserIdentity */
+	private $lastModifiedByConstraint;
+
+	public function __construct( IDatabase $dbr, ActorMigration $actorMigration ) {
+		$this->dbr = $dbr;
+		$this->actorMigration = $actorMigration;
+	}
+
+	public function addModifiedByConstraint( string $userName ): void {
+		$this->modifiedByConstraints[] = $this->getUserForQuery( $userName );
+	}
+
+	public function addNotModifiedByConstraint( string $userName ): void {
+		$this->notModifiedByConstraints[] = $this->getUserForQuery( $userName );
+	}
+
+	public function addCreatedByConstraint( string $userName ): void {
+		$this->createdByConstraint = $this->getUserForQuery( $userName );
+	}
+
+	public function addNotCreatedByConstraint( string $userName ): void {
+		$this->notCreatedByConstraints[] = $this->getUserForQuery( $userName );
+	}
+
+	public function addLastModifiedByConstraint( string $userName ): void {
+		$this->lastModifiedByConstraint = $this->getUserForQuery( $userName );
+	}
+
+	public function addNotLastModifiedByConstraint( string $userName ): void {
+		$this->notLastModifiedByConstraints[] = $this->getUserForQuery( $userName );
+	}
+
+	/**
+	 * Combine the constraints into a single condition suitable for inclusion in a WHERE clause.
+	 * @return string
+	 */
+	public function getWhere(): string {
+		$conds = [];
+
+		$modifiedByQuery = $this->getSubqueryForConstraint( $this->modifiedByConstraints );
+		if ( $modifiedByQuery ) {
+			$conds[] = "page_id IN $modifiedByQuery";
+		}
+
+		$notModifiedByQuery = $this->getSubqueryForConstraint( $this->notModifiedByConstraints );
+		if ( $notModifiedByQuery ) {
+			$conds[] = "NOT EXISTS $notModifiedByQuery";
+		}
+
+		$lastModifiedByQuery = $this->getSubqueryForConstraint(
+			[ $this->lastModifiedByConstraint ],
+			$this->notLastModifiedByConstraints,
+			'rev_id'
+		);
+		if ( $lastModifiedByQuery ) {
+			$conds[] = "page_latest IN $lastModifiedByQuery";
+		}
+
+		$createdByQuery = $this->getSubqueryForConstraint(
+			[ $this->createdByConstraint ],
+			$this->notCreatedByConstraints,
+			'rev_page',
+			[ 'rev_parent_id' => 0 ]
+		);
+		if ( $createdByQuery ) {
+			$conds[] = "page_id IN $createdByQuery";
+		}
+
+		return $this->dbr->makeList( $conds, IDatabase::LIST_AND );
+	}
+
+	private function getUserForQuery( string $userName ): ?UserIdentity {
+		return User::newFromName( $userName, false ) ?: null;
+	}
+
+	/**
+	 * Construct a subquery for filtering revisions based on given user-specific criteria.
+	 * @param UserIdentity[] $constraints -users to include in the result set
+	 * @param UserIdentity[] $notConstraints - users to exclude from the result set
+	 * @param string $selectField - field name to select from the revision table
+	 * @param array $conds - additional query conditions
+	 * @return string|null - the subquery, or null if no constraints were given
+	 */
+	private function getSubqueryForConstraint(
+		array $constraints,
+		array $notConstraints = [],
+		string $selectField = 'rev_page',
+		array $conds = []
+	): ?string {
+		$constraints = array_filter( $constraints );
+		$notConstraints = array_filter( $notConstraints );
+		if ( !$constraints && !$notConstraints ) {
+			return null;
+		}
+
+		$constraintActorQuery = $this->actorMigration->getWhere(
+			$this->dbr,
+			'rev_user',
+			$constraints
+		);
+
+		$notConstraintActorQuery = $this->actorMigration->getWhere(
+			$this->dbr,
+			'rev_user',
+			$notConstraints
+		);
+
+		if ( $constraints ) {
+			$conds[] = $constraintActorQuery['conds'];
+		}
+
+		if ( $notConstraints ) {
+			$conds[] = "NOT ({$notConstraintActorQuery['conds']})";
+		}
+
+		$conds[] = 'rev_page=page_id';
+
+		return (string)$this->dbr->buildSelectSubquery(
+			[ 'revision' ] + $constraintActorQuery['tables'] + $notConstraintActorQuery['tables'],
+			[ $selectField ],
+			$conds,
+			__METHOD__,
+			[],
+			$constraintActorQuery['joins'] + $notConstraintActorQuery['joins']
+		);
+	}
+}

--- a/extension.json
+++ b/extension.json
@@ -56,7 +56,8 @@
 		"DPL\\Query": "classes/Query.php",
 		"DPL\\UpdateArticle": "classes/UpdateArticle.php",
 		"DPL\\Variables": "classes/Variables.php",
-		"DPL\\SeedTestDatabase": "classes/SeedTestDatabase.php",
+		"DPL\\RevisionJoinBuilder": "classes/RevisionJoinBuilder.php",
+		"DPL\\UserQueryBuilder": "classes/UserQueryBuilder.php",
 		"DynamicPageListHooks": "DynamicPageListHooks.php",
 		"DPL\\DPLIntegrationTestCase": "tests/phpunit/DPLIntegrationTestCase.php"
 	},

--- a/tests/phpunit/DPLIntegrationTestCase.php
+++ b/tests/phpunit/DPLIntegrationTestCase.php
@@ -121,10 +121,10 @@ abstract class DPLIntegrationTestCase extends MediaWikiTestCase {
 	 * @param array $params - DPL invocation parameters
 	 * @return string[]
 	 */
-	protected function getDPLQueryResults( array $params ): array {
+	protected function getDPLQueryResults( array $params, string $format = '%PAGE%' ): array {
 		$params += [
 			// Use a custom format for executing the query to allow easily extracting results
-			'format' => '<div id="dpl-test-query">,%PAGE%,|,</div>'
+			'format' => "<div id=\"dpl-test-query\">,$format,|,</div>"
 		];
 
 		$html = $this->runDPLQuery( $params );

--- a/tests/phpunit/DPLQueryIntegrationTest.php
+++ b/tests/phpunit/DPLQueryIntegrationTest.php
@@ -179,4 +179,167 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 			true
 		);
 	}
+
+	public function testFindPagesNotModifiedByUserInCategory(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 2', 'DPLTestArticle 3', 'DPLTestArticleMultipleCategories' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestCategory',
+				'notmodifiedby' => 'DPLTestUser',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesCreatedByUserInCategory(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticleOtherCategoryWithInfobox' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestOtherCategory',
+				'createdby' => 'FANDOM',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesLastModifiedByUserInCategory(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 1' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestCategory',
+				'lastmodifiedby' => 'DPLTestUser',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesNotLastModifiedByUserInCategory(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 2', 'DPLTestArticle 3', 'DPLTestArticleMultipleCategories' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestCategory',
+				'notlastmodifiedby' => 'DPLTestUser',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesEverModifiedByUserInCategory(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 1', 'DPLTestArticle 2', 'DPLTestArticle 3', 'DPLTestArticleMultipleCategories' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestCategory',
+				'modifiedby' => 'DPLTestAdmin',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesNotCreatedByUserInCategory(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticleMultipleCategories' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestOtherCategory',
+				'notcreatedby' => 'FANDOM',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesViaUserFilterCombinations(): void {
+		$this->assertArrayEquals(
+			[ 'DPLUncategorizedPage' ],
+			$this->getDPLQueryResults( [
+				'modifiedby' => 'DPLTestUser',
+				'notcreatedby' => 'DPLTestAdmin',
+				'notlastmodifiedby' => 'DPLTestUser',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesInCategoryOrderedByLastEdit(): void {
+		$results = $this->getDPLQueryResults( [
+			'category' => 'DPLTestCategory',
+			'ordermethod' => 'lastedit',
+			'order' => 'descending',
+		] );
+
+		$this->assertArrayEquals(
+			[
+				'DPLTestArticle 3',
+				'DPLTestArticle 2',
+				'DPLTestArticleMultipleCategories',
+				'DPLTestArticle 1',
+			],
+			$results,
+			true
+		);
+	}
+
+	public function testFindPagesInCategoryOrderedByFirstEdit(): void {
+		$results = $this->getDPLQueryResults( [
+			'category' => 'DPLTestCategory',
+			'ordermethod' => 'firstedit',
+			'order' => 'descending',
+		] );
+
+		$this->assertArrayEquals(
+			[
+				'DPLTestArticle 2',
+				'DPLTestArticleMultipleCategories',
+				'DPLTestArticle 1',
+				'DPLTestArticle 3',
+			],
+			$results,
+			true
+		);
+	}
+
+	public function testOrderByLastEditAndUser(): void {
+		$results = $this->getDPLQueryResults( [
+			'category' => 'DPLTestCategory',
+			'ordermethod' => 'lastedit,user',
+			'order' => 'descending',
+			'adduser' => 'true',
+			'createdby' => 'DPLTestAdmin'
+		], '%PAGE% %USER%' );
+
+		$this->assertEquals( [
+			'DPLTestArticle 3 DPLTestAdmin',
+			'DPLTestArticle 2 DPLTestAdmin',
+			'DPLTestArticleMultipleCategories DPLTestAdmin',
+			'DPLTestArticle 1 DPLTestUser',
+		], $results );
+	}
+
+	public function testGetPageAuthors(): void {
+		$results = $this->getDPLQueryResults( [
+			'category' => 'DPLTestCategory',
+			'addauthor' => 'true',
+			'order' => 'ascending',
+			'ordermethod' => 'title'
+		], '%PAGE% %USER%' );
+
+		$this->assertEquals( [
+			'DPLTestArticle 1 DPLTestAdmin',
+			'DPLTestArticle 2 DPLTestAdmin',
+			'DPLTestArticle 3 DPLTestAdmin',
+			'DPLTestArticleMultipleCategories DPLTestAdmin',
+		], $results );
+	}
+
+	public function testGetLastEditorsByPage(): void {
+		$results = $this->getDPLQueryResults( [
+			'category' => 'DPLTestCategory',
+			'addlasteditor' => 'true'
+		], '%PAGE% %USER%' );
+
+		$this->assertEquals( [
+			'DPLTestArticle 1 DPLTestUser',
+			'DPLTestArticle 2 DPLTestAdmin',
+			'DPLTestArticle 3 DPLTestAdmin',
+			'DPLTestArticleMultipleCategories DPLTestAdmin',
+		], $results );
+	}
 }

--- a/tests/seed-data.xml
+++ b/tests/seed-data.xml
@@ -250,5 +250,18 @@
 			<text xml:space="preserve">Uncategorized test page</text>
 			<sha1 />
 		</revision>
+		<revision>
+			<id>28</id>
+			<timestamp>2021-09-04T03:01:00Z</timestamp>
+			<contributor>
+				<username>DPLTestUser</username>
+			</contributor>
+			<comment>Page edited</comment>
+			<origin>27</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text xml:space="preserve">Uncategorized test page edit</text>
+			<sha1 />
+		</revision>
 	</page>
 </mediawiki>


### PR DESCRIPTION
Add support for actor migration in DPL via MediaWiki's ActorMigration
abstraction and convert existing user name field references. Factor out
some relevant logic to new helper classes where necessary both to
simplify logic and to avoid naming conflicts from joining multiple
instances of actor-related tables in a single query.

It appears that DPL didn't implement comment migration either, so this
patch also adds support for that to avoid errors on newer MW.