### PR TITLE
CATS-1829 | Update DPL to work with actor migration

### DIFF
--- a/.github/workflows/install-mediawiki.sh
+++ b/.github/workflows/install-mediawiki.sh
@@ -44,4 +44,6 @@ php maintenance/install.php \
 	echo '$wgShowDBErrorBacktrace = true;'
 	echo '$wgDevelopmentWarnings = true;'
 	echo 'wfLoadExtension( "DynamicPageList3" );'
+	# Test using the revision_actor_temp table on MW 1.37
+	echo 'if ( version_compare( MW_VERSION, "1.38", "<" ) ) { $wgActorTableSchemaMigrationStage = SCHEMA_COMPAT_TEMP; }'
 } >> LocalSettings.php

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -10,14 +10,9 @@ jobs:
     strategy:
       matrix:
         include:
-          # Fandom's MW version
-          - mw: 'REL1_33'
-            php: 7.3
-            composer: v1
-            mysql: '5.7'
           # Latest stable MW
-          - mw: 'REL1_36'
-            php: 8.0
+          - mw: 'REL1_37'
+            php: 7.4
             composer: v2
             mysql: '8.0'
           # Latest MW master
@@ -46,10 +41,12 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: intl
+          # Disable XDebug for a performance boost as we do not currently generate coverage reports
+          coverage: none
           tools: composer:${{ matrix.composer }}
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             mediawiki
@@ -64,7 +61,7 @@ jobs:
           key: composer-php${{ matrix.php }}
 
       - name: Fetch MW install script
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: installer
 
@@ -82,15 +79,12 @@ jobs:
           MYSQL_PASSWORD: mw12345
 
       - name: Checkout DPL extension
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: mediawiki/extensions/DynamicPageList3
 
       - name: Run PHPUnit
-        run: |
-          [[ '${{ matrix.mw }}' != 'master' ]] && PHPUNIT_ARGS='--use-normal-tables' ||  PHPUNIT_ARGS=''
-          php tests/phpunit/phpunit.php $PHPUNIT_ARGS extensions/DynamicPageList3/tests/phpunit
-
+        run: php tests/phpunit/phpunit.php $PHPUNIT_ARGS extensions/DynamicPageList3/tests/phpunit
         env:
           # By default MediaWiki creates temporary tables for use in integration tests,
           # which do not play well with DPL's queries. Ensure we use real tables to avoid issues.

--- a/DynamicPageListHooks.php
+++ b/DynamicPageListHooks.php
@@ -250,23 +250,23 @@ class DynamicPageListHooks {
 		$text = $parse->parse( $input, $parser, $reset, $eliminate, true );
 
 		if ( isset( $reset['templates'] ) && $reset['templates'] ) {	// we can remove the templates by save/restore
-			$saveTemplates = $parser->mOutput->mTemplates;
+			$saveTemplates = $parser->getOutput()->mTemplates;
 		}
 		if ( isset( $reset['categories'] ) && $reset['categories'] ) {	// we can remove the categories by save/restore
-			$saveCategories = $parser->mOutput->mCategories;
+			$saveCategories = $parser->getOutput()->mCategories;
 		}
 		if ( isset( $reset['images'] ) && $reset['images'] ) {	// we can remove the images by save/restore
-			$saveImages = $parser->mOutput->mImages;
+			$saveImages = $parser->getOutput()->mImages;
 		}
 		$parsedDPL = $parser->recursiveTagParse( $text );
 		if ( isset( $reset['templates'] ) && $reset['templates'] ) {
-			$parser->mOutput->mTemplates = $saveTemplates;
+			$parser->getOutput()->mTemplates = $saveTemplates;
 		}
 		if ( isset( $reset['categories'] ) && $reset['categories'] ) {
-			$parser->mOutput->mCategories = $saveCategories;
+			$parser->getOutput()->mCategories = $saveCategories;
 		}
 		if ( isset( $reset['images'] ) && $reset['images'] ) {
-			$parser->mOutput->mImages = $saveImages;
+			$parser->getOutput()->mImages = $saveImages;
 		}
 
 		return $parsedDPL;
@@ -303,7 +303,7 @@ class DynamicPageListHooks {
 		$parse = new \DPL\Parse();
 		$dplresult = $parse->parse( $input, $parser, $reset, $eliminate, false );
 		return [ // parser needs to be coaxed to do further recursive processing
-			$parser->getPreprocessor()->preprocessToObj( $dplresult, Parser::PTD_FOR_INCLUSION ),
+			$parser->getPreprocessor()->preprocessToObj( $dplresult, Preprocessor::DOM_FOR_INCLUSION ),
 			'isLocalObj' => true,
 			'title' => $parser->getTitle()
 		];
@@ -474,24 +474,6 @@ class DynamicPageListHooks {
 		}
 	}
 
-	private static function dumpParsedRefs( $parser, $label ) {
-		// if (!preg_match("/Query Q/",$parser->mTitle->getText())) return '';
-		echo '<pre>parser mLinks: ';
-		ob_start();
-		var_dump( $parser->mOutput->mLinks );
-		$a = ob_get_contents();
-		ob_end_clean();
-		echo htmlspecialchars( $a, ENT_QUOTES );
-		echo '</pre>';
-		echo '<pre>parser mTemplates: ';
-		ob_start();
-		var_dump( $parser->mOutput->mTemplates );
-		$a = ob_get_contents();
-		ob_end_clean();
-		echo htmlspecialchars( $a, ENT_QUOTES );
-		echo '</pre>';
-	}
-
 	// remove section markers in case the LabeledSectionTransclusion extension is not installed.
 	public static function removeSectionMarkers( $in, $assocArgs = [], $parser = null ) {
 		return '';
@@ -528,23 +510,23 @@ class DynamicPageListHooks {
 	public static function endReset( &$parser, $text ) {
 		if ( !self::$createdLinks['resetdone'] ) {
 			self::$createdLinks['resetdone'] = true;
-			foreach ( $parser->mOutput->mCategories as $key => $val ) {
+			foreach ( $parser->getOutput()->mCategories as $key => $val ) {
 				if ( array_key_exists( $key, self::$fixedCategories ) ) {
 					self::$fixedCategories[$key] = $val;
 				}
 			}
 			// $text .= self::dumpParsedRefs($parser,"before final reset");
 			if ( self::$createdLinks['resetLinks'] ) {
-				$parser->mOutput->mLinks = [];
+				$parser->getOutput()->mLinks = [];
 			}
 			if ( self::$createdLinks['resetCategories'] ) {
-				$parser->mOutput->mCategories = self::$fixedCategories;
+				$parser->getOutput()->mCategories = self::$fixedCategories;
 			}
 			if ( self::$createdLinks['resetTemplates'] ) {
-				$parser->mOutput->mTemplates = [];
+				$parser->getOutput()->mTemplates = [];
 			}
 			if ( self::$createdLinks['resetImages'] ) {
-				$parser->mOutput->mImages = [];
+				$parser->getOutput()->mImages = [];
 			}
 			// $text .= self::dumpParsedRefs($parser,"after final reset");
 			self::$fixedCategories = [];
@@ -557,38 +539,38 @@ class DynamicPageListHooks {
 		if ( isset( self::$createdLinks ) ) {
 			// self::dumpParsedRefs($parser,"before final eliminate");
 			if ( array_key_exists( 0, self::$createdLinks ) ) {
-				foreach ( $parser->mOutput->getLinks() as $nsp => $link ) {
+				foreach ( $parser->getOutput()->getLinks() as $nsp => $link ) {
 					if ( !array_key_exists( $nsp, self::$createdLinks[0] ) ) {
 						continue;
 					}
 					// echo ("<pre> elim: created Links [$nsp] = ". count(DynamicPageListHooks::$createdLinks[0][$nsp])."</pre>\n");
-					// echo ("<pre> elim: parser  Links [$nsp] = ". count($parser->mOutput->mLinks[$nsp])			 ."</pre>\n");
-					$parser->mOutput->mLinks[$nsp] = array_diff_assoc( $parser->mOutput->mLinks[$nsp], self::$createdLinks[0][$nsp] );
-					// echo ("<pre> elim: parser  Links [$nsp] nachher = ". count($parser->mOutput->mLinks[$nsp])	  ."</pre>\n");
-					if ( count( $parser->mOutput->mLinks[$nsp] ) == 0 ) {
-						unset( $parser->mOutput->mLinks[$nsp] );
+					// echo ("<pre> elim: parser  Links [$nsp] = ". count($parser->getOutput()->mLinks[$nsp])			 ."</pre>\n");
+					$parser->getOutput()->mLinks[$nsp] = array_diff_assoc( $parser->getOutput()->mLinks[$nsp], self::$createdLinks[0][$nsp] );
+					// echo ("<pre> elim: parser  Links [$nsp] nachher = ". count($parser->getOutput()->mLinks[$nsp])	  ."</pre>\n");
+					if ( count( $parser->getOutput()->mLinks[$nsp] ) == 0 ) {
+						unset( $parser->getOutput()->mLinks[$nsp] );
 					}
 				}
 			}
 			if ( isset( self::$createdLinks ) && array_key_exists( 1, self::$createdLinks ) ) {
-				foreach ( $parser->mOutput->mTemplates as $nsp => $tpl ) {
+				foreach ( $parser->getOutput()->mTemplates as $nsp => $tpl ) {
 					if ( !array_key_exists( $nsp, self::$createdLinks[1] ) ) {
 						continue;
 					}
 					// echo ("<pre> elim: created Tpls [$nsp] = ". count(DynamicPageListHooks::$createdLinks[1][$nsp])."</pre>\n");
-					// echo ("<pre> elim: parser  Tpls [$nsp] = ". count($parser->mOutput->mTemplates[$nsp])			."</pre>\n");
-					$parser->mOutput->mTemplates[$nsp] = array_diff_assoc( $parser->mOutput->mTemplates[$nsp], self::$createdLinks[1][$nsp] );
-					// echo ("<pre> elim: parser  Tpls [$nsp] nachher = ". count($parser->mOutput->mTemplates[$nsp])	 ."</pre>\n");
-					if ( count( $parser->mOutput->mTemplates[$nsp] ) == 0 ) {
-						unset( $parser->mOutput->mTemplates[$nsp] );
+					// echo ("<pre> elim: parser  Tpls [$nsp] = ". count($parser->getOutput()->mTemplates[$nsp])			."</pre>\n");
+					$parser->getOutput()->mTemplates[$nsp] = array_diff_assoc( $parser->getOutput()->mTemplates[$nsp], self::$createdLinks[1][$nsp] );
+					// echo ("<pre> elim: parser  Tpls [$nsp] nachher = ". count($parser->getOutput()->mTemplates[$nsp])	 ."</pre>\n");
+					if ( count( $parser->getOutput()->mTemplates[$nsp] ) == 0 ) {
+						unset( $parser->getOutput()->mTemplates[$nsp] );
 					}
 				}
 			}
 			if ( isset( self::$createdLinks ) && array_key_exists( 2, self::$createdLinks ) ) {
-				$parser->mOutput->mCategories = array_diff_assoc( $parser->mOutput->mCategories, self::$createdLinks[2] );
+				$parser->getOutput()->mCategories = array_diff_assoc( $parser->getOutput()->mCategories, self::$createdLinks[2] );
 			}
 			if ( isset( self::$createdLinks ) && array_key_exists( 3, self::$createdLinks ) ) {
-				$parser->mOutput->mImages = array_diff_assoc( $parser->mOutput->mImages, self::$createdLinks[3] );
+				$parser->getOutput()->mImages = array_diff_assoc( $parser->getOutput()->mImages, self::$createdLinks[3] );
 			}
 			// $text .= self::dumpParsedRefs($parser,"after final eliminate".$parser->mTitle->getText());
 		}

--- a/classes/Article.php
+++ b/classes/Article.php
@@ -12,7 +12,6 @@ namespace DPL;
 
 use MediaWiki\MediaWikiServices;
 use Title;
-use User;
 
 class Article {
 	/**
@@ -310,13 +309,7 @@ class Article {
 			// CONTRIBUTION, CONTRIBUTOR
 			if ( $parameters->getParameter( 'addcontribution' ) ) {
 				$article->mContribution = $row['contribution'];
-				// This is the wrong check since the ActorMigration may be in progress
-				// https://www.mediawiki.org/wiki/Actor_migration
-				if ( class_exists( 'ActorMigration' ) ) {
-					$article->mContributor = User::newFromActorId( $row['contributor'] )->getName();
-				} else {
-					$article->mContributor = $row['contributor'];
-				}
+				$article->mContributor = $row['contributor'];
 				$article->mContrib = substr( '*****************', 0, (int)round( log( $row['contribution'] ) ) );
 			}
 

--- a/classes/Article.php
+++ b/classes/Article.php
@@ -209,7 +209,11 @@ class Article {
 	public static function newFromRow( $row, Parameters $parameters, \Title $title, $pageNamespace, $pageTitle ) {
 		global $wgLang;
 
-		$contentLanguage = MediaWikiServices::getInstance()->getContentLanguage();
+		$services = MediaWikiServices::getInstance();
+		$contentLanguage = $services->getContentLanguage();
+		$languageConverter = $services->getLanguageConverterFactory()->getLanguageConverter(
+			$contentLanguage
+		);
 
 		$article = new Article( $title, $pageNamespace );
 
@@ -236,9 +240,9 @@ class Article {
 
 		// get first char used for category-style output
 		if ( isset( $row['sortkey'] ) ) {
-			$article->mStartChar = $contentLanguage->convert( $contentLanguage->firstChar( $row['sortkey'] ) );
+			$article->mStartChar = $languageConverter->convert( $contentLanguage->firstChar( $row['sortkey'] ) );
 		} else {
-			$article->mStartChar = $contentLanguage->convert( $contentLanguage->firstChar( $pageTitle ) );
+			$article->mStartChar = $languageConverter->convert( $contentLanguage->firstChar( $pageTitle ) );
 		}
 
 		$article->mID = intval( $row['page_id'] );

--- a/classes/Query.php
+++ b/classes/Query.php
@@ -2279,7 +2279,7 @@ class Query {
 	 * @throws MWException
 	 */
 	private function addRevisionActorTable( string $revTableAlias ): string {
-		$revIdField = $revTableAlias !== '' ? "$revTableAlias.rev_id" : 'rev_id';
+		$revIdField = $revTableAlias !== '' ? "$revTableAlias.rev_id" : 'rev.rev_id';
 
 		// Use a JOINed actor ID field from the revision_comment_temp table if mandated by the
 		$readStage = $this->actorMigrationStage & SCHEMA_COMPAT_READ_MASK;
@@ -2290,7 +2290,7 @@ class Query {
 			$this->addTable( 'revision_actor_temp', $tmpTable );
 			$this->addJoin( $tmpTable, [ 'JOIN', "$tmpTable.revactor_rev = $revIdField" ] );
 		} else {
-			$actorField = $revTableAlias !== '' ? "$revTableAlias.rev_actor" : 'rev_actor';
+			$actorField = $revTableAlias !== '' ? "$revTableAlias.rev_actor" : 'rev.rev_actor';
 		}
 
 		return $actorField;
@@ -2307,8 +2307,8 @@ class Query {
 		$revCommentTable = $revTableAlias !== '' ? "{$revTableAlias}_temp_rev_comment" : 'temp_rev_comment';
 		$commentTable = $revTableAlias !== '' ? "{$revTableAlias}_comment" : 'comment';
 
-		$revIdField = $revTableAlias !== '' ? "$revTableAlias.rev_id" : 'rev_id';
-		$revCommentField = $revTableAlias !== '' ? "$revTableAlias.rev_comment" : 'rev_comment';
+		$revIdField = $revTableAlias !== '' ? "$revTableAlias.rev_id" : "rev.rev_id";
+		$revCommentField = $revTableAlias !== '' ? "$revTableAlias.rev_comment" : "rev.rev_comment";
 
 		$this->addTable( 'revision_comment_temp', $revCommentTable );
 		$this->addTable( 'comment', $commentTable );

--- a/classes/lister/Lister.php
+++ b/classes/lister/Lister.php
@@ -991,23 +991,24 @@ class Lister {
 	 */
 	protected function parseImageUrlWithPath( $article ) {
 		$imageUrl = '';
+		$repoGroup = MediaWikiServices::getInstance()->getRepoGroup();
 		if ( $article instanceof \DPL\Article ) {
 			if ( $article->mNamespace == NS_FILE ) {
 				// calculate URL for existing images
 				// $img = Image::newFromName($article->mTitle->getText());
-				$img = wfFindFile( \Title::makeTitle( NS_FILE, $article->mTitle->getText() ) );
+				$img = $repoGroup->findFile( \Title::makeTitle( NS_FILE, $article->mTitle->getText() ) );
 				if ( $img && $img->exists() ) {
 					$imageUrl = $img->getURL();
 				} else {
 					$fileTitle = \Title::makeTitleSafe( NS_FILE, $article->mTitle->getDBKey() );
-					$imageUrl = \RepoGroup::singleton()->getLocalRepo()->newFile( $fileTitle )->getPath();
+					$imageUrl = $repoGroup->getLocalRepo()->newFile( $fileTitle )->getPath();
 				}
 			}
 		} else {
 			$title = \Title::newfromText( 'File:' . $article );
 			if ( $title !== null ) {
 				$fileTitle   = \Title::makeTitleSafe( 6, $title->getDBKey() );
-				$imageUrl = \RepoGroup::singleton()->getLocalRepo()->newFile( $fileTitle )->getPath();
+				$imageUrl = $repoGroup->getLocalRepo()->newFile( $fileTitle )->getPath();
 			}
 		}
 
@@ -1034,7 +1035,7 @@ class Lister {
 			} else {
 				$pageText = '<br/>';
 			}
-			$text = $this->parser->fetchTemplate( \Title::newFromText( $title ) );
+			$text = $this->parser->fetchTemplateAndTitle( \Title::newFromText( $title ) )[0];
 			if ( ( count( $this->pageTextMatchRegex ) <= 0 || $this->pageTextMatchRegex[0] == '' || !preg_match( $this->pageTextMatchRegex[0], $text ) == false ) && ( count( $this->pageTextMatchNotRegex ) <= 0 || $this->pageTextMatchNotRegex[0] == '' || preg_match( $this->pageTextMatchNotRegex[0], $text ) == false ) ) {
 				if ( $this->includePageMaxLength > 0 && ( strlen( $text ) > $this->includePageMaxLength ) ) {
 					$text = LST::limitTranscludedText( $text, $this->includePageMaxLength, ' [[' . $title . '|..→]]' );

--- a/tests/phpunit/DPLIntegrationTestCase.php
+++ b/tests/phpunit/DPLIntegrationTestCase.php
@@ -6,14 +6,14 @@ use DOMXPath;
 use ImportStreamSource;
 use MediaWiki\Auth\AuthManager;
 use MediaWiki\MediaWikiServices;
-use MediaWikiTestCase;
+use MediaWikiIntegrationTestCase;
 use ParserOptions;
 use RequestContext;
 use Title;
 use User;
 use WikiImporter;
 
-abstract class DPLIntegrationTestCase extends MediaWikiTestCase {
+abstract class DPLIntegrationTestCase extends MediaWikiIntegrationTestCase {
 	/**
 	 * Guard condition to ensure we only import seed data once per test suite run.
 	 * @var bool
@@ -119,12 +119,13 @@ abstract class DPLIntegrationTestCase extends MediaWikiTestCase {
 	/**
 	 * Convenience function to return the list of page titles matching a DPL query
 	 * @param array $params - DPL invocation parameters
+	 * @param string $format - DPL output format
 	 * @return string[]
 	 */
-	protected function getDPLQueryResults( array $params ): array {
+	protected function getDPLQueryResults( array $params, string $format = '%PAGE%' ): array {
 		$params += [
 			// Use a custom format for executing the query to allow easily extracting results
-			'format' => '<div id="dpl-test-query">,%PAGE%,|,</div>'
+			'format' => "<div id=\"dpl-test-query\">,$format,|,</div>"
 		];
 
 		$html = $this->runDPLQuery( $params );

--- a/tests/phpunit/DPLQueryIntegrationTest.php
+++ b/tests/phpunit/DPLQueryIntegrationTest.php
@@ -179,4 +179,167 @@ class DPLQueryIntegrationTest extends DPLIntegrationTestCase {
 			true
 		);
 	}
+
+	public function testFindPagesNotModifiedByUserInCategory(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 2', 'DPLTestArticle 3', 'DPLTestArticleMultipleCategories' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestCategory',
+				'notmodifiedby' => 'DPLTestUser',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesCreatedByUserInCategory(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticleOtherCategoryWithInfobox' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestOtherCategory',
+				'createdby' => 'FANDOM',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesLastModifiedByUserInCategory(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 1' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestCategory',
+				'lastmodifiedby' => 'DPLTestUser',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesNotLastModifiedByUserInCategory(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 2', 'DPLTestArticle 3', 'DPLTestArticleMultipleCategories' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestCategory',
+				'notlastmodifiedby' => 'DPLTestUser',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesEverModifiedByUserInCategory(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticle 1', 'DPLTestArticle 2', 'DPLTestArticle 3', 'DPLTestArticleMultipleCategories' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestCategory',
+				'modifiedby' => 'DPLTestAdmin',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesNotCreatedByUserInCategory(): void {
+		$this->assertArrayEquals(
+			[ 'DPLTestArticleMultipleCategories' ],
+			$this->getDPLQueryResults( [
+				'category' => 'DPLTestOtherCategory',
+				'notcreatedby' => 'FANDOM',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesViaUserFilterCombinations(): void {
+		$this->assertArrayEquals(
+			[ 'DPLUncategorizedPage' ],
+			$this->getDPLQueryResults( [
+				'modifiedby' => 'DPLTestUser',
+				'notcreatedby' => 'DPLTestAdmin',
+				'notlastmodifiedby' => 'DPLTestUser',
+			] ),
+			true
+		);
+	}
+
+	public function testFindPagesInCategoryOrderedByLastEdit(): void {
+		$results = $this->getDPLQueryResults( [
+			'category' => 'DPLTestCategory',
+			'ordermethod' => 'lastedit',
+			'order' => 'descending',
+		] );
+
+		$this->assertArrayEquals(
+			[
+				'DPLTestArticle 3',
+				'DPLTestArticle 2',
+				'DPLTestArticleMultipleCategories',
+				'DPLTestArticle 1',
+			],
+			$results,
+			true
+		);
+	}
+
+	public function testFindPagesInCategoryOrderedByFirstEdit(): void {
+		$results = $this->getDPLQueryResults( [
+			'category' => 'DPLTestCategory',
+			'ordermethod' => 'firstedit',
+			'order' => 'descending',
+		] );
+
+		$this->assertArrayEquals(
+			[
+				'DPLTestArticle 2',
+				'DPLTestArticleMultipleCategories',
+				'DPLTestArticle 1',
+				'DPLTestArticle 3',
+			],
+			$results,
+			true
+		);
+	}
+
+	public function testOrderByLastEditAndUser(): void {
+		$results = $this->getDPLQueryResults( [
+			'category' => 'DPLTestCategory',
+			'ordermethod' => 'lastedit,user',
+			'order' => 'descending',
+			'adduser' => 'true',
+			'createdby' => 'DPLTestAdmin'
+		], '%PAGE% %USER%' );
+
+		$this->assertEquals( [
+			'DPLTestArticle 3 DPLTestAdmin',
+			'DPLTestArticle 2 DPLTestAdmin',
+			'DPLTestArticleMultipleCategories DPLTestAdmin',
+			'DPLTestArticle 1 DPLTestUser',
+		], $results );
+	}
+
+	public function testGetPageAuthors(): void {
+		$results = $this->getDPLQueryResults( [
+			'category' => 'DPLTestCategory',
+			'addauthor' => 'true',
+			'order' => 'ascending',
+			'ordermethod' => 'title'
+		], '%PAGE% %USER%' );
+
+		$this->assertEquals( [
+			'DPLTestArticle 1 DPLTestAdmin',
+			'DPLTestArticle 2 DPLTestAdmin',
+			'DPLTestArticle 3 DPLTestAdmin',
+			'DPLTestArticleMultipleCategories DPLTestAdmin',
+		], $results );
+	}
+
+	public function testGetLastEditorsByPage(): void {
+		$results = $this->getDPLQueryResults( [
+			'category' => 'DPLTestCategory',
+			'addlasteditor' => 'true'
+		], '%PAGE% %USER%' );
+
+		$this->assertEquals( [
+			'DPLTestArticle 1 DPLTestUser',
+			'DPLTestArticle 2 DPLTestAdmin',
+			'DPLTestArticle 3 DPLTestAdmin',
+			'DPLTestArticleMultipleCategories DPLTestAdmin',
+		], $results );
+	}
 }

--- a/tests/seed-data.xml
+++ b/tests/seed-data.xml
@@ -250,5 +250,18 @@
 			<text xml:space="preserve">Uncategorized test page</text>
 			<sha1 />
 		</revision>
+		<revision>
+			<id>28</id>
+			<timestamp>2021-09-04T03:01:00Z</timestamp>
+			<contributor>
+				<username>DPLTestUser</username>
+			</contributor>
+			<comment>Page edited</comment>
+			<origin>27</origin>
+			<model>wikitext</model>
+			<format>text/x-wiki</format>
+			<text xml:space="preserve">Uncategorized test page edit</text>
+			<sha1 />
+		</revision>
 	</page>
 </mediawiki>


### PR DESCRIPTION
Make DPL use appropriate joins on the actor and the revision_actor_temp table
depending on the current actor table schema migration stage. For now, avoid
any major change to the structure of the actual queries.

Drop testing on 1.33 and retain only 1.37 and MW master.